### PR TITLE
error in comparing the equality of np.ndarray

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tensorflow"]
 	path = tensorflow
 	url = https://github.com/tensorflow/tensorflow
-	branch = r1.0
+	branch = r1.2.1

--- a/tensorflow_fold/blocks/layers.py
+++ b/tensorflow_fold/blocks/layers.py
@@ -604,6 +604,15 @@ class ScopedLayer(Layer):
     return result
 
 
+def __array_eq(arr0, arr1):
+  """Comparing the equality of two arrays. Handling np.ndarray differently.
+  """
+  boolean = arr0 == arr1
+  if isinstance(boolean, np.ndarray):
+    boolean = boolean.all()
+  return boolean
+
+
 def get_local_arguments(fun, is_method=False):
   """Return the callers arguments and non-default keyword arguments.
 
@@ -626,7 +635,7 @@ def get_local_arguments(fun, is_method=False):
 
   args = [lvals[k] for k in arg_names]
   kwargs_a = [(k, lvals[k], d) for (k, d) in zip(kwarg_names, argspec.defaults)]
-  kwargs = [(k, v) for (k, v, d) in kwargs_a if v != d]
+  kwargs = [(k, v) for (k, v, d) in kwargs_a if not __array_eq(v, d)]
 
   if is_method: args = args[1:]   # strip off the self argument
   return (args, kwargs)


### PR DESCRIPTION
Hey all,

This fixes an error, in tensorflow_fold/blocks/layers.py, where comparing directly the equality of np.ndarray throws an error.

To reproduce the error, run:
import tensorflow as tf
import tensorflow_fold as td
td.Embedding(2, 2, initializer=np.asarray([[1,2], [2,3]]))

Or if you run this example, https://github.com/tensorflow/fold/blob/master/tensorflow_fold/g3doc/sentiment.ipynb
At cell 17, it will throw the same error.

Thanks!